### PR TITLE
Updated 'invoke' method to return a Promise to match HubConnection signature

### DIFF
--- a/dist/src/SignalRMock.d.ts
+++ b/dist/src/SignalRMock.d.ts
@@ -1,6 +1,6 @@
 export declare class SignalRMock {
     on(action: string, callback: (...args: any) => void): void;
-    invoke(action: string, ...args: any): void;
+    invoke<T = any>(action: string, ...args: any): Promise<T>;
     off(action: string, callback: (args: any[]) => void): void;
     onclose(callback?: (error?: Error) => void): void;
     start(): Promise<void>;

--- a/dist/src/SignalRMock.js
+++ b/dist/src/SignalRMock.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.SignalRMock = void 0;
 var subscribers_1 = require("./subscribers");
 var invokes_1 = require("./invokes");
 var SignalRMock = /** @class */ (function () {
@@ -13,7 +14,10 @@ var SignalRMock = /** @class */ (function () {
         for (var _i = 1; _i < arguments.length; _i++) {
             args[_i - 1] = arguments[_i];
         }
-        invokes_1.addInvoke({ action: action, args: args });
+        return new Promise(function (resolve) {
+            invokes_1.addInvoke({ action: action, args: args });
+            resolve();
+        });
     };
     SignalRMock.prototype.off = function (action, callback) {
         subscribers_1.removeSubscriber(action, callback);

--- a/dist/src/api.js
+++ b/dist/src/api.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.clear = exports.verify = exports.publish = void 0;
 var invokes_1 = require("./invokes");
 var subscribers_1 = require("./subscribers");
 function publish(action) {

--- a/dist/src/invokes.js
+++ b/dist/src/invokes.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.clearInvokes = exports.addInvoke = exports.getInvokes = void 0;
 var invokes = [];
 function getInvokes() {
     return invokes;

--- a/dist/src/subscribers.js
+++ b/dist/src/subscribers.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.removeSubscriber = exports.clearSubscribers = exports.addSubscriber = exports.getSubscribers = void 0;
 var subscribers = [];
 function getSubscribers() {
     return subscribers;

--- a/src/SignalRMock.ts
+++ b/src/SignalRMock.ts
@@ -6,8 +6,11 @@ export class SignalRMock {
     addSubscriber({ action, callback });
   }
 
-  invoke(action: string, ...args: any): void {
-    addInvoke({ action, args });
+  invoke<T = any>(action: string, ...args: any) : Promise<T> {
+    return new Promise<T>((resolve) => {
+      addInvoke({ action, args });
+      resolve();
+    });
   }
 
   off(action: string, callback: (args: any[]) => void): void {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "types": [
       "node",
       "cypress"
-    ]
+    ],
+    "lib": ["esnext", "dom"]
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Updated 'invoke' method to return a Promise so that it matches the signature of SignaR's 'HubConnection'.

Currently when hub connection is being chained as shown below it causes an error:

```
export let myHub = (<any>window).signalrMock || new HubConnectionBuilder()
    .withUrl("./myhub", signalROptions)
    .withAutomaticReconnect()
    .configureLogging(LogLevel.Warning)
    .build();

    myHub.start()
        .then(() => console.log("connected"))
        .catch(error => console.log('Error connecting to hub'));

    myHub.invoke('myMethod', 'param')
        .then(() => { console.log('Invoked'); })
        .catch(() => console.log('Error invoking'));
```